### PR TITLE
[codex] Add arena-based tests for String8 and Array

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS
+
+This repository houses the cxb C++ utility library and its tests.
+
+## Layout
+- `cxb/` – core library headers and sources
+- `tests/` – unit tests
+
+## Development notes
+- Use `rg` for searching the codebase.
+- Before building tests, fetch submodules:
+  `git submodule update --init --recursive`
+- Build and run tests:
+  - `cmake -S . -B build -DCXB_BUILD_TESTS=ON`
+  - `cmake --build build`
+  - `ctest --test-dir build`
+- Avoid the C++ standard library when cxb provides equivalent functionality (e.g., use `String8` instead of `std::string`).
+

--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -823,6 +823,7 @@ struct Array {
 
     Array() : data{nullptr}, len{0} {}
     Array(T* data, size_t len) : data{data}, len{len} {}
+    Array(std::initializer_list<T> xs) : data{(T*) xs.begin()}, len{xs.size()} {}
     Array(Arena* a, std::initializer_list<T> xs) : data{nullptr}, len{0} {
         data = arena_push_fast<T>(a, xs.size());
         len = xs.size();


### PR DESCRIPTION
## Summary
- expand Array to support brace initialization via initializer list constructor
- refine arena-backed String8 and Array tests to avoid redundant behavior and standard library usage
- document repository layout and development guidelines in AGENTS.md

## Testing
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*
- `cmake -S . -B build -DCXB_BUILD_TESTS=ON` *(fails: deps/Catch2 missing CMakeLists.txt)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68bd14c1fb2083268e9b12df83fa29b6