### PR TITLE
[codex] Implement arena-backed allocator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,19 @@ This repository houses the cxb C++ utility library and its tests.
 ## Development
 Use `rg` for searching the codebase.
 
+### Environment Setup
+Preferred: use Nix to match CI:
+```bash
+nix develop ./ci --system aarch64-linux --command bash ./ci/ci.sh
+```
+If Nix installation fails (e.g., HTTP 403) or is unavailable, install clang and build manually:
+```bash
+apt-get update && apt-get install -y clang
+CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON
+CXX=clang++ CC=clang cmake --build build
+ctest --test-dir build
+```
+
 ### Building and Testing
 Before building tests, fetch submodules:
 `git submodule update --init --recursive`

--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -53,6 +53,7 @@ free the memory
 
 /* SECTION: configuration */
 #if __cpp_concepts
+#include <concepts>
 #define CXB_USE_CXX_CONCEPTS
 #endif
 
@@ -342,6 +343,7 @@ struct Arena;
 struct String8;
 template <typename T>
 struct Array;
+struct Allocator;
 
 #ifdef CXB_USE_CXX_CONCEPTS
 template <typename A, typename T>
@@ -394,6 +396,8 @@ CXB_C_TYPE struct Arena {
 
     // TODO: freelist
     CXB_C_COMPAT_END
+
+    CXB_MAYBE_INLINE Allocator make_alloc();
 };
 
 CXB_C_EXPORT Arena* arena_make(ArenaParams params);
@@ -723,6 +727,11 @@ CXB_C_TYPE struct Allocator {
     }
 };
 
+Allocator make_arena_alloc(Arena* arena);
+CXB_MAYBE_INLINE Allocator Arena::make_alloc() {
+    return make_arena_alloc(this);
+}
+
 CXB_C_COMPAT_BEGIN
 extern Allocator heap_alloc;
 CXB_C_COMPAT_END
@@ -792,7 +801,7 @@ CXB_C_TYPE struct String8 {
 
         String8 c = *this;
         c.data = c.data + ii;
-        c.len = max(0ll, jj - ii + 1);
+        c.len = max<i64>(0, jj - ii + 1);
         c.not_null_term = ii + c.len == len ? this->not_null_term : true;
         return c;
     }


### PR DESCRIPTION
## Summary
- add a function and Arena method to obtain an Allocator backed by an Arena
- ensure arena allocator frees only tail allocations and supports clearing the arena
- cover arena allocator behaviour with new tests
- document environment setup and guard C++ concepts include

## Testing
- `curl -L https://nixos.org/nix/install | sh` *(fails: CONNECT tunnel failed, response 403)*
- `apt-get update && apt-get install -y clang`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdda71b2ec8326a285d755b78fffd2