### PR TITLE
[codex] HashMap: add reserve APIs, bucket-size ctors and benchmark comparing to std::unordered_map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if(CXB_BUILD_TESTS)
     add_test_exe(bench_string tests/benchmarks/bench_string.cpp 1)
     add_test_exe(bench_string_header tests/benchmarks/bench_string_header.cpp 1)
     add_test_exe(bench_std_headers tests/benchmarks/bench_std_headers.cpp 0)
+    add_test_exe(bench_hm tests/benchmarks/bench_hm.cpp 1)
 
     add_test(NAME test_array COMMAND test_array)
     add_test(NAME test_string COMMAND test_string)

--- a/tests/benchmarks/bench_hm.cpp
+++ b/tests/benchmarks/bench_hm.cpp
@@ -1,0 +1,80 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+size_t hash(const int& x);
+#include <cxb/cxb.h>
+
+size_t hash(const int& x) {
+    return static_cast<size_t>(x);
+}
+
+TEST_CASE("HashMap vs std::unordered_map", "[benchmark][HashMap]") {
+    constexpr int N = 2000;
+
+    std::vector<int> keys;
+    keys.reserve(N);
+    for(int i = 0; i < N; ++i) keys.push_back(i);
+
+    BENCHMARK("AHashMap<int,int> insert N") {
+        AHashMap<int, int> hm;
+        hm.reserve(static_cast<size_t>(N * 2));
+        for(int i = 0; i < N; ++i) {
+            hm.put({keys[i], i});
+        }
+        return hm.len;
+    };
+
+    BENCHMARK("std::unordered_map<int,int> insert N") {
+        std::unordered_map<int, int> m;
+        m.reserve(N * 2);
+        for(int i = 0; i < N; ++i) {
+            m.emplace(keys[i], i);
+        }
+        return m.size();
+    };
+
+    AHashMap<int, int> hm_pre;
+    hm_pre.reserve(static_cast<size_t>(N * 2));
+    for(int i = 0; i < N; ++i) hm_pre.put({keys[i], i});
+
+    std::unordered_map<int, int> m_pre;
+    m_pre.reserve(N * 2);
+    for(int i = 0; i < N; ++i) m_pre.emplace(keys[i], i);
+
+    BENCHMARK("AHashMap<int,int> lookup N") {
+        volatile int sum = 0; // prevent optimization
+        for(int i = 0; i < N; ++i) {
+            if(hm_pre.contains(keys[i])) sum += hm_pre[keys[i]];
+        }
+        return sum;
+    };
+
+    BENCHMARK("std::unordered_map<int,int> lookup N") {
+        volatile int sum = 0; // prevent optimization
+        for(int i = 0; i < N; ++i) {
+            auto it = m_pre.find(keys[i]);
+            if(it != m_pre.end()) sum += it->second;
+        }
+        return sum;
+    };
+
+    BENCHMARK("AHashMap<int,int> erase N") {
+        AHashMap<int, int> hm;
+        hm.reserve(static_cast<size_t>(N * 2));
+        for(int i = 0; i < N; ++i) hm.put({keys[i], i});
+        for(int i = 0; i < N; ++i) {
+            hm.erase(keys[i]);
+        }
+        return hm.len;
+    };
+
+    BENCHMARK("std::unordered_map<int,int> erase N") {
+        std::unordered_map<int, int> m;
+        m.reserve(N * 2);
+        for(int i = 0; i < N; ++i) m.emplace(keys[i], i);
+        for(int i = 0; i < N; ++i) {
+            m.erase(keys[i]);
+        }
+        return m.size();
+    };
+}


### PR DESCRIPTION
benchmarks\n\n- HashMap\n  - Added round_up_pow2(u64) utility.\n  - Added constructor HashMap(Arena*, size_t) to pre-size buckets.\n  - Added reserve(Arena*, size_t) to set bucket count (power-of-two, min 64) and rehash.\n  - maybe_rehash(Arena*) now grows from existing size without stored defaults.\n\n- MHashMap / AHashMap\n  - Added constructor MHashMap(size_t, Allocator*) and AHashMap(size_t, Allocator*).\n  - Added reserve(size_t) to pre-size and rehash.\n  - Refactored MHashMap to use common _reserve(size_t) from both reserve() and maybe_rehash().\n\n- Benchmarks\n  - tests/benchmarks/bench_hm.cpp: Benchmarks for insert/lookup/erase vs std::unordered_map.\n\n- Build/CI\n  - CMakeLists: added bench_hm target (not registered as a ctest).\n\nAll code formatted with scripts/format.sh and tests pass.