### PR TITLE
[codex] HashMap: add reserve APIs, bucket-size ctors and benchmark comparing to std::unordered_map

### DIFF
--- a/tests/benchmarks/bench_hm.cpp
+++ b/tests/benchmarks/bench_hm.cpp
@@ -1,5 +1,7 @@
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <unordered_map>
+#include <vector>
 
 size_t hash(const int& x);
 #include <cxb/cxb.h>


### PR DESCRIPTION
## Summary
- include `<vector>` and `<unordered_map>` in HashMap benchmark to fix missing declarations

## Testing
- `./scripts/format.sh`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdea1b617c8326ac977a16a17b250c