### PR TITLE
[codex] Add array tests and coverage scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,13 @@ jobs:
           BUILD_TYPE: ${{ matrix.build_type }}
         run: |
           nix develop ./scripts/ci --system ${{ matrix.nix_system }} --command bash ./scripts/ci/ci.sh
+      - name: Coverage
+        if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang' && matrix.build_type == 'Debug' && matrix.nix_system == 'x86_64-linux'
+        run: |
+          nix develop ./scripts/ci --system ${{ matrix.nix_system }} --command bash ./scripts/ci/coverage.sh
+      - name: Upload coverage report
+        if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang' && matrix.build_type == 'Debug' && matrix.nix_system == 'x86_64-linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: build/coverage/coverage.txt

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ An unorthodox C++ base library with a focus on performance & simplicity
 Current Header Compile Times:
 * `cxb-cxx.h`: 164±150ms on Apple M1 Max
 
+![coverage](https://img.shields.io/badge/coverage-unknown-lightgrey)
+
 ## Development
 
 For development setup, building, and testing see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+
+## Coverage
+
+Run `./scripts/ci/coverage.sh` to build the project with clang coverage instrumentation and generate `coverage.txt`. CI uploads this report as an artifact for the Linux clang Debug job.
 
 # TODOs
 - [ ] formatting

--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -617,7 +617,7 @@ inline void array_emplace_back(A& xs, Arena* arena, Args&&... args)
     requires ArrayLike<A>
 #endif
 {
-    using T = decltype(xs.data[0]);
+    using T = std::remove_reference_t<decltype(xs.data[0])>;
 
     ASSERT((void*) xs.data >= (void*) arena->start && (void*) xs.data < arena->end, "array not allocated on arena");
     ASSERT((void*) (xs.data + xs.len) == (void*) (arena->start + arena->pos), "cannot push unless array is at the end");
@@ -634,9 +634,8 @@ inline void array_pop_back(A& xs, Arena* arena)
 {
     ASSERT((void*) xs.data >= (void*) arena->start && (void*) xs.data < arena->end, "array not allocated on arena");
     ASSERT((void*) (xs.data + xs.len) == (void*) (arena->start + arena->pos), "cannot pop unless array is at the end");
+    ::destroy(&xs.data[xs.len - 1], 1);
     arena_pop_to(arena, arena->pos - sizeof(xs.data[0]));
-
-    ::destroy(&xs.data[xs.len], 1);
     xs.len -= 1;
 }
 

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure submodules are present
+git submodule update --init --recursive
+
+export CC=clang
+export CXX=clang++
+LLVM_PROFDATA=${LLVM_PROFDATA:-llvm-profdata-18}
+LLVM_COV=${LLVM_COV:-llvm-cov-18}
+
+build_dir="build/coverage"
+rm -rf "$build_dir"
+cmake -B "$build_dir" -DCMAKE_BUILD_TYPE=Debug -DCXB_BUILD_TESTS=ON -DCXB_BUILD_C_API_TESTS=ON \
+  -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping" -DCMAKE_EXE_LINKER_FLAGS="-fprofile-instr-generate"
+cmake --build "$build_dir" --config Debug -j
+
+pushd "$build_dir" >/dev/null
+LLVM_PROFILE_FILE="cxb-%p.profraw" ctest --output-on-failure
+"$LLVM_PROFDATA" merge cxb-*.profraw -o coverage.profdata
+"$LLVM_COV" report $(find . -maxdepth 1 -type f -name 'test_*') -instr-profile=coverage.profdata > coverage.txt
+cat coverage.txt
+popd >/dev/null

--- a/tests/test_array.cpp
+++ b/tests/test_array.cpp
@@ -2,6 +2,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cxb/cxb.h>
 
+struct Pair {
+    int x;
+    int y;
+};
+
 TEST_CASE("simple initializer list", "AArray") {
     Array<int> xs = {get_perm(), {1, 2, 3}};
     REQUIRE(xs.len == 3);
@@ -132,4 +137,45 @@ TEST_CASE("operator<", "AArray") {
         REQUIRE(seq5 == seq1);
     }
     REQUIRE(heap_alloc_data.n_active_bytes == allocated_bytes_before);
+}
+
+TEST_CASE("array_emplace_back and pop_back", "Array") {
+    AArenaTmp tmp = begin_scratch();
+    Arena* a = tmp.arena;
+    Array<Pair> xs{arena_push_fast<Pair>(a, 0), 0};
+    array_emplace_back(xs, a, 1, 2);
+    array_emplace_back(xs, a, 3, 4);
+    REQUIRE(xs.len == 2);
+    REQUIRE(xs[0].x == 1);
+    REQUIRE(xs[0].y == 2);
+    REQUIRE(xs[1].x == 3);
+    REQUIRE(xs[1].y == 4);
+    array_pop_back(xs, a);
+    REQUIRE(xs.len == 1);
+    REQUIRE(xs[0].x == 1);
+    REQUIRE(xs[0].y == 2);
+}
+
+TEST_CASE("array_insert and resize", "Array") {
+    AArenaTmp tmp = begin_scratch();
+    Arena* a = tmp.arena;
+    Array<int> xs = {a, {1, 2, 3}};
+    int raw[] = {4, 5};
+    Array<int> to_insert{raw, 2};
+    array_insert(xs, a, to_insert, 1);
+    REQUIRE(xs.len == 5);
+    REQUIRE(xs[0] == 1);
+    REQUIRE(xs[1] == 4);
+    REQUIRE(xs[2] == 5);
+    REQUIRE(xs[3] == 2);
+    REQUIRE(xs[4] == 3);
+    array_resize(xs, a, 7, 9);
+    REQUIRE(xs.len == 7);
+    REQUIRE(xs[5] == 9);
+    REQUIRE(xs[6] == 9);
+    array_resize(xs, a, 3);
+    REQUIRE(xs.len == 3);
+    REQUIRE(xs[0] == 1);
+    REQUIRE(xs[1] == 4);
+    REQUIRE(xs[2] == 5);
 }


### PR DESCRIPTION
## Summary
- add regression tests for array emplace/back, insert, and resize helpers
- fix arena-based array emplace and pop helpers
- document and wire up initial clang coverage reporting

## Testing
- `ctest --test-dir build --output-on-failure`
- `./scripts/ci/coverage.sh` *(fails: cxb-*.profraw: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeaff8eac83269c07c735938263f9