### PR TITLE
[codex] Add dynamic coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: build/coverage/coverage.txt
+          path: |
+            build/coverage/coverage.txt
+            build/coverage/coverage.json
+      - name: Publish coverage badge
+        if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang' && matrix.build_type == 'Debug' && matrix.nix_system == 'x86_64-linux'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/coverage
+          enable_jekyll: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An unorthodox C++ base library with a focus on performance & simplicity
 Current Header Compile Times:
 * `cxb-cxx.h`: 164±150ms on Apple M1 Max
 
-![coverage](https://img.shields.io/badge/coverage-unknown-lightgrey)
+![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/codex/cxb/gh-pages/coverage.json)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- detect llvm-* tools, parse coverage, and emit Shields.io JSON
- publish coverage badge via GitHub Pages and update workflow
- display dynamic coverage badge in README

## Testing
- `./scripts/format.sh`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`
- `./scripts/ci/coverage.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdf7b68148832686ebcdda8cdda8cd