### PR TITLE
[codex] Fix coverage badge publish permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     name: ${{ matrix.nix_system }} ${{ matrix.compiler }} ${{ matrix.build_type }} (${{ matrix.os }})
     # All jobs run in parallel; format check runs conditionally within this job
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         # NOTE: this is flattened intentionally, such that it's easier to read
@@ -99,7 +101,7 @@ jobs:
             build/coverage/coverage.txt
             build/coverage/coverage.json
       - name: Publish coverage badge
-        if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang' && matrix.build_type == 'Debug' && matrix.nix_system == 'x86_64-linux'
+        if: github.event_name == 'push' && matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang' && matrix.build_type == 'Debug' && matrix.nix_system == 'x86_64-linux'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- grant gh-pages publishing step contents: write permission
- limit coverage badge publishing to push events only

## Testing
- `./scripts/format.sh`
- `git submodule update --init --recursive`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build` *(failed: interrupted to save time)*

------
https://chatgpt.com/codex/tasks/task_e_68be03bfea1c8326bbad799365ae87e5