### PR TITLE
[codex] Add String8 search utilities

### DIFF
--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -320,3 +320,32 @@ TEST_CASE("Utf8Iterator with unicode", "[Utf8Iterator]") {
 
     end_scratch(scratch);
 }
+
+TEST_CASE("string8_contains and find", "[String8]") {
+    String8 s = S8_LIT("hello world");
+    REQUIRE(string8_contains(s, S8_LIT("hello")));
+    REQUIRE(s.contains(S8_LIT("world")));
+    REQUIRE(string8_find(s, S8_LIT("world")) == 6);
+    REQUIRE(s.find(S8_LIT("hello")) == 0);
+    REQUIRE_FALSE(string8_contains(s, S8_LIT("abc")));
+    REQUIRE(string8_find(s, S8_LIT("abc")) == SIZE_MAX);
+}
+
+TEST_CASE("string8_trim", "[String8]") {
+    String8 s = S8_LIT("   abc \t");
+    String8 trimmed = string8_trim(s, S8_LIT("\t "));
+    REQUIRE(trimmed == S8_LIT("abc"));
+
+    String8 lead = string8_trim(s, S8_LIT("\t "), true, false);
+    REQUIRE(lead == S8_LIT("abc \t"));
+
+    REQUIRE(s.trim(S8_LIT("\t "), false, true) == S8_LIT("   abc"));
+}
+
+TEST_CASE("string8_contains_chars", "[String8]") {
+    String8 s = S8_LIT("hello world");
+    REQUIRE(string8_contains_chars(s, S8_LIT("ow")));
+    REQUIRE_FALSE(string8_contains_chars(s, S8_LIT("xyz")));
+    REQUIRE(s.contains_chars(S8_LIT("hw")));
+    REQUIRE_FALSE(s.contains_chars(S8_LIT("xyz")));
+}


### PR DESCRIPTION
## Summary
- add `string8_contains`, `string8_find`, `string8_trim`, and `string8_contains_chars` utilities and expose as member functions
- consolidate String8 tests into `test_string.cpp` covering contains, find, trim, and contains_chars

## Testing
- `git submodule update --init --recursive`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfff8ca6483269d8265f9b88fc422