### PR TITLE
[codex] Remove initializer-list Array constructor and add StaticArray factory

### DIFF
--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -398,6 +398,8 @@ struct Arena;
 struct String8;
 template <typename T>
 struct Array;
+template <typename T, size_t N>
+struct StaticArray;
 struct Allocator;
 
 #ifdef CXB_USE_CXX_CONCEPTS
@@ -982,7 +984,7 @@ struct Array {
 
     Array() : data{nullptr}, len{0} {}
     Array(T* data, size_t len) : data{data}, len{len} {}
-    Array(std::initializer_list<T> xs) : data{const_cast<T*>(xs.begin())}, len{xs.size()} {}
+    Array(std::initializer_list<T>) = delete;
     Array(Arena* a, std::initializer_list<T> xs) : data{nullptr}, len{0} {
         data = arena_push_fast<T>(a, xs.size());
         len = xs.size();
@@ -1083,15 +1085,42 @@ struct Array {
         array_pop_all(*this, arena);
     }
     CXB_INLINE void insert(Arena* arena, T value, size_t i) {
-        array_insert(*this, arena, Array<T>{{value}}, i);
+        StaticArray<T, 1> tmp{{value}};
+        array_insert(*this, arena, tmp, i);
     }
     CXB_INLINE void insert(Arena* arena, Array<T> to_insert, size_t i) {
+        array_insert(*this, arena, to_insert, i);
+    }
+    template <size_t N>
+    CXB_INLINE void insert(Arena* arena, const StaticArray<T, N>& to_insert, size_t i) {
         array_insert(*this, arena, to_insert, i);
     }
     CXB_INLINE void extend(Arena* arena, Array<T> to_append) {
         array_extend(*this, arena, to_append);
     }
+    template <size_t N>
+    CXB_INLINE void extend(Arena* arena, const StaticArray<T, N>& to_append) {
+        array_extend(*this, arena, to_append);
+    }
 };
+
+template <typename T, size_t N>
+struct StaticArray {
+    T data[N];
+    size_t len = N;
+
+    CXB_INLINE operator Array<T>() & {
+        return Array<T>{data, len};
+    }
+    CXB_INLINE operator Array<T>() && = delete;
+};
+
+template <typename T, size_t N>
+CXB_INLINE StaticArray<T, N> make_static_array(const T (&xs)[N]) {
+    StaticArray<T, N> sa{};
+    ::copy(sa.data, xs, N);
+    return sa;
+}
 
 // *SECTION*: formatting library
 

--- a/tests/test_arena.cpp
+++ b/tests/test_arena.cpp
@@ -90,10 +90,17 @@ TEST_CASE("array insert", "[Arena]") {
     xs.push_back(arena, 10);
     REQUIRE((void*) (arena->start + arena->pos) == (void*) (xs.data + xs.len));
 
-    xs.extend(arena, {20, 30, 50, 80});
+    auto more = make_static_array<int>({20, 30, 50, 80});
+    xs.extend(arena, more);
     REQUIRE((void*) (arena->start + arena->pos) == (void*) (xs.data + xs.len));
-
     REQUIRE(xs.len == 5);
+
+    auto insert_vals = make_static_array<int>({40, 60});
+    xs.insert(arena, insert_vals, 2);
+    REQUIRE(xs.len == 7);
+    REQUIRE(xs[2] == 40);
+    REQUIRE(xs[3] == 60);
+    REQUIRE(xs[4] == 30);
 }
 
 TEST_CASE("String8 arena member functions", "[String8][Arena]") {

--- a/tests/test_hm.cpp
+++ b/tests/test_hm.cpp
@@ -19,12 +19,8 @@ TEST_CASE("basic", "[HashMap]") {
     }
 
     REQUIRE(kvs.len == 1);
-    REQUIRE(kvs.extend(a,
-                       {
-                           {7, 9},
-                           {3, 5},
-                           {11, 9},
-                       }));
+    auto kv_arr = make_static_array<KvPair<int, int>>({{7, 9}, {3, 5}, {11, 9}});
+    REQUIRE(kvs.extend(a, kv_arr));
     REQUIRE(kvs.contains(1));
     REQUIRE(kvs.contains(7));
     REQUIRE(kvs.contains(3));

--- a/tests/test_static_array.cpp
+++ b/tests/test_static_array.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cxb/cxb.h>
+#include <type_traits>
+
+TEST_CASE("make_static_array conversion", "StaticArray") {
+    auto sa = make_static_array<int>({1, 2, 3});
+    Array<int> xs{sa};
+    REQUIRE(xs.len == 3);
+    REQUIRE(xs[0] == 1);
+    REQUIRE(xs[1] == 2);
+    REQUIRE(xs[2] == 3);
+
+    static_assert(!std::is_constructible_v<Array<int>, decltype(make_static_array<int>({1, 2, 3}))>);
+}


### PR DESCRIPTION
## Summary
- delete `Array(std::initializer_list<T>)` to avoid dangling references
- introduce `StaticArray` and `make_static_array` factory for safe stack arrays
- overload array helpers to accept `StaticArray` directly and copy initializer data
- cover temporary static array misuse and static array insertion with new tests

## Testing
- `./scripts/format.sh`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc9e392883268d9e45d12f560f3c