### PR TITLE
[codex] Add String8 search utilities

### DIFF
--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -839,15 +839,18 @@ CXB_C_TYPE struct String8 {
         return data[len - 1];
     }
     CXB_MAYBE_INLINE String8 slice(i64 i = 0, i64 j = -1) const {
-        if(!data) {
-            return {};
+        if(!data || len == 0) {
+            return String8{.data = (char*) "", .len = 0, .not_null_term = false};
         }
-        i64 ii = clamp(i < 0 ? (i64) len + i : i, (i64) 0, len == 0 ? 0 : (i64) len - 1);
-        i64 jj = clamp(j < 0 ? (i64) len + j : j, (i64) 0, len == 0 ? 0 : (i64) len - 1);
+        i64 ii = clamp(i < 0 ? (i64) len + i : i, (i64) 0, (i64) len);
+        i64 jj = clamp(j < 0 ? (i64) len + j : j, (i64) 0, (i64) len - 1);
+        if(jj < ii) {
+            return String8{.data = (char*) "", .len = 0, .not_null_term = false};
+        }
 
         String8 c = *this;
         c.data = c.data + ii;
-        c.len = max<i64>(0, jj - ii + 1);
+        c.len = jj - ii + 1;
         c.not_null_term = ii + c.len == len ? this->not_null_term : true;
         return c;
     }
@@ -1927,7 +1930,10 @@ CXB_PURE String8 string8_trim(const String8& s, String8 chars, bool leading, boo
             end--;
         }
     }
-    return s.slice((i64) start, start < end ? (i64) end - 1 : (i64) start - 1);
+    if(start >= end) {
+        return S8_LIT("");
+    }
+    return s.slice((i64) start, (i64) end - 1);
 }
 
 #define MSTRING_NT(a) (MString8{.data = nullptr, .len = 0, .not_null_term = false, .capacity = 0, .allocator = (a)})

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -161,6 +161,13 @@ TEST_CASE("String8 slice", "[String8]") {
     }
 }
 
+TEST_CASE("String8 slice out of range", "[String8]") {
+    String8 s = S8_LIT("Hello");
+    REQUIRE(s.slice(5) == S8_LIT(""));
+    REQUIRE(s.slice(6) == S8_LIT(""));
+    REQUIRE(s.slice(3, 2) == S8_LIT(""));
+}
+
 TEST_CASE("String8 copy", "[String8]") {
     AString8 original("Hello, World!");
     AString8 copy = original.copy();
@@ -340,6 +347,11 @@ TEST_CASE("string8_trim", "[String8]") {
     REQUIRE(lead == S8_LIT("abc \t"));
 
     REQUIRE(s.trim(S8_LIT("\t "), false, true) == S8_LIT("   abc"));
+
+    String8 all_ws = S8_LIT("   ");
+    REQUIRE(string8_trim(all_ws, S8_LIT(" ")) == S8_LIT(""));
+    REQUIRE(string8_trim(all_ws, S8_LIT(" "), true, false) == S8_LIT(""));
+    REQUIRE(string8_trim(all_ws, S8_LIT(" "), false, true) == S8_LIT(""));
 }
 
 TEST_CASE("string8_contains_chars", "[String8]") {


### PR DESCRIPTION
## Summary
- ensure `string8_trim` returns an empty string when all characters are trimmed
- make `String8::slice` yield an empty slice for out-of-range indices
- add unit tests for out-of-range slicing and fully trimmed strings

## Testing
- `git submodule update --init --recursive`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be1004d820832680d12d16b38d0051