### PR TITLE
[codex] Add floating point string8_parse overload

### DIFF
--- a/cxb/cxb-cxx.h
+++ b/cxb/cxb-cxx.h
@@ -79,6 +79,7 @@ CXB_C_COMPAT_BEGIN
 #include <string.h>
 CXB_C_COMPAT_END
 
+#include <charconv>
 #include <initializer_list>
 #include <limits>
 #include <new>
@@ -946,8 +947,7 @@ struct ParseResult {
 };
 
 template <typename T>
-CXB_MAYBE_INLINE std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, ParseResult<T>> string8_parse(
-    String8 str, u64 base = 10) {
+CXB_MAYBE_INLINE std::enable_if_t<std::is_integral_v<T>, ParseResult<T>> string8_parse(String8 str, u64 base = 10) {
     ASSERT(base <= 10, "TODO: support bases > 10");
     ParseResult<T> result = {.value = {}, .exists = str.len > 0, .n_consumed = 0};
     u64 num_negs = 0;
@@ -972,6 +972,24 @@ CXB_MAYBE_INLINE std::enable_if_t<std::is_integral_v<T> || std::is_floating_poin
         if(num_negs > 1) result.exists = false;
     }
     result.exists = result.n_consumed > 0;
+    return result;
+}
+
+template <typename T>
+CXB_MAYBE_INLINE std::enable_if_t<std::is_floating_point_v<T>, ParseResult<T>> string8_parse(String8 str,
+                                                                                             u64 base = 10) {
+    ASSERT(base == 10, "only base 10 supported for floats");
+    ParseResult<T> result = {.value = {}, .exists = str.len > 0, .n_consumed = 0};
+    const char* begin = str.data;
+    const char* end = str.data + str.len;
+    auto fc = std::from_chars(begin, end, result.value);
+    if(fc.ec == std::errc()) {
+        result.n_consumed = (size_t) (fc.ptr - begin);
+        result.exists = result.n_consumed > 0;
+    } else {
+        result.exists = false;
+        result.n_consumed = 0;
+    }
     return result;
 }
 

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cxb/cxb.h>
 
@@ -319,4 +320,12 @@ TEST_CASE("Utf8Iterator with unicode", "[Utf8Iterator]") {
     REQUIRE(codepoints[10] == '!');
 
     end_scratch(scratch);
+}
+
+TEST_CASE("string8_parse floating point", "[String8][Parse]") {
+    String8 s = S8_LIT("3.14f");
+    auto res = string8_parse<f64>(s);
+    REQUIRE(res.exists);
+    REQUIRE(res.value == Catch::Approx(3.14));
+    REQUIRE(res.n_consumed == 4);
 }


### PR DESCRIPTION
## Summary
- parse floating-point values from `String8` using `std::from_chars`
- cover floating-point parsing with new unit test

## Testing
- `cmake --build build --target test_string -- -j8`
- `./build/test_string`

------
https://chatgpt.com/codex/tasks/task_e_68be1404c6188326b5f9f26ec1f024f1