### PR TITLE
[codex] Add String8 fuzz target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,18 @@ if(CXB_BUILD_TESTS)
     add_test(NAME test_hm COMMAND test_hm)
     add_test(NAME test_algos COMMAND test_algos)
 
+    add_executable(string_fuzz tests/fuzz/string_fuzz.cpp ${CXB_SRCS})
+    target_include_directories(string_fuzz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CXB_DEPS_INCLUDE_DIRS})
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        target_compile_options(string_fuzz PRIVATE
+            -fsanitize=fuzzer,address,undefined
+            -fno-omit-frame-pointer
+        )
+        target_link_options(string_fuzz PRIVATE
+            -fsanitize=fuzzer,address,undefined
+        )
+    endif()
+
     # if(CXB_BUILD_C_API_TESTS)
     if(0)  # TODO
         # Pure C test

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ For development setup, building, and testing see [docs/DEVELOPMENT.md](docs/DEVE
 
 Run `./scripts/ci/coverage.sh` to build the project with clang coverage instrumentation and generate `coverage.txt`. CI uploads this report as an artifact for the Linux clang Debug job.
 
+# Fuzzing
+
+Build with tests enabled and run the fuzz target:
+
+```
+./build/string_fuzz -max_total_time=60
+```
+
 # TODOs
 - [ ] formatting
     - [x] print & format alternative (using fmtlib for floats)

--- a/tests/fuzz/string_fuzz.cpp
+++ b/tests/fuzz/string_fuzz.cpp
@@ -1,0 +1,60 @@
+#include "cxb/cxb-cxx.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    ArenaTmp scratch = begin_scratch();
+    Arena* arena = scratch.arena;
+
+    String8 input{.data = (char*) data, .len = size, .not_null_term = true};
+    String8 str = arena_push_string8(arena, input);
+
+    size_t idx = 0;
+    while(idx < size) {
+        u8 op = data[idx++] % 5;
+        switch(op) {
+            case 0: {
+                if(idx < size) {
+                    string8_push_back(str, arena, (char) data[idx++]);
+                }
+                break;
+            }
+            case 1: {
+                if(idx < size) {
+                    size_t max_len = size - idx;
+                    u8 len_byte = data[idx];
+                    idx += 1;
+                    size_t len = len_byte % (max_len + 1);
+                    String8 to_append{.data = (char*) data + idx, .len = len, .not_null_term = true};
+                    string8_extend(str, arena, to_append);
+                    idx += len;
+                }
+                break;
+            }
+            case 2: {
+                if(str.len > 0) {
+                    size_t i = data[idx % size] % (str.len + 1);
+                    size_t j = data[(idx + 1) % size] % (str.len + 1);
+                    String8 slice = str.slice((i64) i, (i64) j);
+                    (void) slice;
+                }
+                break;
+            }
+            case 3: {
+                Array<u32> codepoints = decode_string8(arena, str);
+                (void) codepoints;
+                break;
+            }
+            case 4: {
+                Utf8Iter iter = make_utf8_iter(str);
+                Utf8IterBatch batch = {};
+                while(iter.next(batch)) {}
+                break;
+            }
+        }
+    }
+
+    end_scratch(scratch);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add string_fuzz LLVM fuzzer exercising String8 operations
- Wire up string_fuzz build with sanitizers
- Document running the fuzz target

## Testing
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be2156c1ec8326b534b028713fcc6b