### PR TITLE
[codex] Add String8 fuzz target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,9 @@ if(CXB_BUILD_TESTS)
     add_test(NAME test_hm COMMAND test_hm)
     add_test(NAME test_algos COMMAND test_algos)
 
-    add_executable(string_fuzz tests/fuzz/string_fuzz.cpp ${CXB_SRCS})
-    target_include_directories(string_fuzz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CXB_DEPS_INCLUDE_DIRS})
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        add_executable(string_fuzz tests/fuzz/string_fuzz.cpp ${CXB_SRCS})
+        target_include_directories(string_fuzz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CXB_DEPS_INCLUDE_DIRS})
         target_compile_options(string_fuzz PRIVATE
             -fsanitize=fuzzer,address,undefined
             -fno-omit-frame-pointer

--- a/tests/fuzz/string_fuzz.cpp
+++ b/tests/fuzz/string_fuzz.cpp
@@ -42,8 +42,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 break;
             }
             case 3: {
-                Array<u32> codepoints = decode_string8(arena, str);
+                ArenaTmp decode_scratch = begin_scratch();
+                Array<u32> codepoints = decode_string8(decode_scratch.arena, str);
                 (void) codepoints;
+                end_scratch(decode_scratch);
                 break;
             }
             case 4: {


### PR DESCRIPTION
## Summary
- Add string_fuzz LLVM fuzzer exercising String8 operations
- Wire up string_fuzz build with sanitizers
- Document running the fuzz target
- Isolate scratch arena for decode_string8 and guard fuzz target for Clang

## Testing
- `git submodule update --init --recursive`
- `CXX=clang++ CC=clang cmake -S . -B build -DCXB_BUILD_TESTS=ON`
- `CXX=clang++ CC=clang cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be6d6d84708326913ed6234b9afb64