### PR TITLE
[codex] Limit coverage to library sources

### DIFF
--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -32,7 +32,9 @@ cmake --build "$build_dir" --config Debug -j
 pushd "$build_dir" >/dev/null
 LLVM_PROFILE_FILE="cxb-%p.profraw" ctest --output-on-failure
 "$LLVM_PROFDATA" merge cxb-*.profraw -o coverage.profdata
-"$LLVM_COV" report $(find . -maxdepth 1 -type f -name 'test_*') -instr-profile=coverage.profdata > coverage.txt
+"$LLVM_COV" report $(find . -maxdepth 1 -type f -name 'test_*') \
+  -instr-profile=coverage.profdata \
+  -ignore-filename-regex='(deps/|tests/|^build/)' > coverage.txt
 cat coverage.txt
 
 # Parse total line coverage and emit Shields.io JSON


### PR DESCRIPTION
## Summary
- ignore deps and tests when computing coverage to only measure `cxb/` sources

## Testing
- `./scripts/ci/coverage.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf10d30e448326b5b5ed3477379621